### PR TITLE
Fix release version 0.6.0 into 0.6 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # swagger-finatra
 Add Swagger support for Finatra (1.6 and 2.2.0) web framework.
 
-It requires Java 8 from version 0.6.0.
+It requires Java 8 from version 0.6
 
 # Getting started
 ## Gradle
@@ -15,11 +15,11 @@ It requires Java 8 from version 0.6.0.
 
 ##### Scala 2.10, Finatra 2.2.0
 
-	compile "com.github.xiaodongw:swagger-finatra_2.10:0.6.0"
+	compile "com.github.xiaodongw:swagger-finatra_2.10:0.6"
 
 ##### Scala 2.11, Finatra 2.2.0
 
-	compile "com.github.xiaodongw:swagger-finatra_2.11:0.6.0"
+	compile "com.github.xiaodongw:swagger-finatra_2.11:0.6"
 
 ## SBT
 	resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/releases/"
@@ -28,7 +28,7 @@ It requires Java 8 from version 0.6.0.
 
 ##### Finatra 2.2.0
 
-    libraryDependencies += "com.github.xiaodongw" %% "swagger-finatra" % "0.6.0"
+    libraryDependencies += "com.github.xiaodongw" %% "swagger-finatra" % "0.6"
 
 ## Add document information for you controller
     object SampleSwagger extends Swagger


### PR DESCRIPTION
Maven central repostory version is 0.6, not 0.6.0 :smile:
https://mvnrepository.com/artifact/com.github.xiaodongw/swagger-finatra_2.11/0.6
