### PR TITLE
Fix broken swagger url from 2.1.4 to 2.2.6

### DIFF
--- a/src/main/scala/com/github/xiaodongw/swagger/finatra/SwaggerController.scala
+++ b/src/main/scala/com/github/xiaodongw/swagger/finatra/SwaggerController.scala
@@ -17,6 +17,6 @@ class SwaggerController(docPath: String = "/api-docs", swagger: Swagger) extends
 
   get(s"${docPath}/ui") { request: Request =>
     response.temporaryRedirect
-        .location("/webjars/swagger-ui/2.1.4/index.html?url=/api-docs/model")
+        .location("/webjars/swagger-ui/2.2.6/index.html?url=/api-docs/model")
   }
 }


### PR DESCRIPTION
### Problem
Current swagger version is [org.webjars:swagger-ui:2.2.6](https://github.com/xiaodongw/swagger-finatra/blob/master/build.gradle#L24), but swagger webjar url indicate [2.1.4](https://github.com/xiaodongw/swagger-finatra/blob/master/src/main/scala/com/github/xiaodongw/swagger/finatra/SwaggerController.scala#L20)
Sync gradle version and [url in SwaggerController](https://github.com/xiaodongw/swagger-finatra/blob/master/src/main/scala/com/github/xiaodongw/swagger/finatra/SwaggerController.scala#L20) to `2.2.6`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xiaodongw/swagger-finatra/24)
<!-- Reviewable:end -->
