### PR TITLE
Initial draft at simpler swagger registration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: java
 jdk:
-  - oraclejdk7
+  - oraclejdk8
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,8 @@ dependencies {
   compile "org.scala-lang:scala-library:${scalaVersion}",
     'io.swagger:swagger-core:1.5.10',
     "io.swagger:swagger-scala-module_${scalaVersionMain}:1.0.2",
-    "org.webjars:swagger-ui:2.2.6"
+    "org.webjars:swagger-ui:2.2.6",
+    'net.bytebuddy:byte-buddy:1.5.9'
 
   testCompile "org.scalatest:scalatest_${scalaVersionMain}:3.0.0",
     'joda-time:joda-time:2.9.4'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.2.1-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.2.1-all.zip

--- a/src/main/scala/com/github/xiaodongw/swagger/finatra/FinatraOperation.scala
+++ b/src/main/scala/com/github/xiaodongw/swagger/finatra/FinatraOperation.scala
@@ -2,9 +2,8 @@ package com.github.xiaodongw.swagger.finatra
 
 import io.swagger.models.parameters._
 import io.swagger.models.properties.RefProperty
-import io.swagger.models.{Swagger, Operation, RefModel, Response}
+import io.swagger.models._
 import io.swagger.util.Json
-
 import scala.collection.JavaConverters._
 import scala.reflect.runtime.universe._
 
@@ -24,6 +23,12 @@ class FinatraOperation(operation: Operation) {
       .property(swagger.registerModel[T])
 
     operation.parameter(param)
+
+    operation
+  }
+
+  def request[T <: Product : TypeTag](implicit swagger: Swagger): Operation = {
+    swagger.register[T].foreach(operation.parameter)
 
     operation
   }

--- a/src/main/scala/com/github/xiaodongw/swagger/finatra/FinatraSwagger.scala
+++ b/src/main/scala/com/github/xiaodongw/swagger/finatra/FinatraSwagger.scala
@@ -1,9 +1,22 @@
 package com.github.xiaodongw.swagger.finatra
 
-import io.swagger.converter.ModelConverters
-import io.swagger.models.properties.Property
-import io.swagger.models.{Operation, Path, Swagger}
-
+import com.fasterxml.jackson.databind.{JavaType, ObjectMapper}
+import com.google.inject.{Inject => GInject}
+import com.twitter.finagle.http.Request
+import com.twitter.finatra.request.{FormParam, QueryParam, RouteParam, Header => HeaderParam}
+import io.swagger.converter.{ModelConverter, ModelConverterContext, ModelConverters}
+import io.swagger.jackson.ModelResolver
+import io.swagger.models._
+import io.swagger.models.parameters._
+import io.swagger.models.properties.{Property, RefProperty}
+import io.swagger.util.Json
+import java.lang.annotation.Annotation
+import java.lang.reflect.ParameterizedType
+import java.util
+import javax.inject.{Inject => JInject}
+import net.bytebuddy.ByteBuddy
+import net.bytebuddy.description.`type`.TypeDescription
+import net.bytebuddy.description.modifier.Visibility
 import scala.collection.JavaConverters._
 import scala.reflect.runtime._
 import scala.reflect.runtime.universe._
@@ -14,24 +27,228 @@ object FinatraSwagger {
   implicit def convertToFinatraSwagger(swagger: Swagger): FinatraSwagger = new FinatraSwagger(swagger)
 }
 
+sealed trait ModelParam {
+  val name: String
+  val description: String
+  val required: Boolean
+  val typ: Class[_]
+}
+
+sealed trait FinatraRequestParam
+case class RouteRequestParam(name: String, typ: Class[_], description: String = "", required: Boolean = true) extends FinatraRequestParam with ModelParam
+case class QueryRequestParam(name: String, typ: Class[_], description: String = "", required: Boolean = true) extends FinatraRequestParam with ModelParam
+case class BodyRequestParam(description: String = "", name: String, typ: Class[_], innerOptionType: Option[java.lang.reflect.Type] = None) extends FinatraRequestParam
+case class RequestInjectRequestParam(name: String) extends FinatraRequestParam
+case class HeaderRequestParam(name: String, required: Boolean = true, description: String = "", typ: Class[_]) extends FinatraRequestParam with ModelParam
+case class FormRequestParam(name: String, description: String = "", required: Boolean = true, typ: Class[_]) extends FinatraRequestParam with ModelParam
+
+object Resolvers {
+  class ScalaOptionResolver(objectMapper: ObjectMapper) extends ModelResolver(objectMapper) {
+    override def resolveProperty(
+      propType: JavaType,
+      context: ModelConverterContext,
+      annotations: Array[Annotation],
+      next: util.Iterator[ModelConverter]): Property = {
+      if (propType.getRawClass == classOf[Option[_]]) {
+        try {
+          return super.resolveProperty(propType.containedType(0), context, annotations, next)
+        } catch {
+          case _: Exception =>
+        }
+      }
+
+      super.resolveProperty(propType, context, annotations, next)
+    }
+  }
+
+  def register(objectMapper: ObjectMapper = Json.mapper): Unit = {
+    ModelConverters.getInstance().addConverter(new ScalaOptionResolver(objectMapper))
+  }
+}
+
 class FinatraSwagger(swagger: Swagger) {
+  /**
+   * Register a request object that contains body information/route information/etc
+   *
+   * @tparam T
+   * @return
+   */
+  def register[T: TypeTag]: List[Parameter] = {
+    val properties = getFinatraProps[T]
+
+    val className = currentMirror.runtimeClass(typeOf[T]).getName
+
+    val swaggerProps =
+      properties.collect {
+        case x: ModelParam => x
+      }.map {
+        case param @ (x: RouteRequestParam) =>
+          new PathParameter().
+            name(param.name).
+            description(param.description).
+            required(param.required).
+            property(registerModel(param.typ))
+        case param @ (x: QueryRequestParam) =>
+          new QueryParameter().
+            name(param.name).
+            description(param.description).
+            required(param.required).
+            property(registerModel(param.typ))
+        case param @ (x: HeaderRequestParam) =>
+          new HeaderParameter().
+            name(param.name).
+            description(param.description).
+            required(param.required).
+            property(registerModel(param.typ))
+        case param @ (x: FormRequestParam) =>
+          new FormParameter().
+            name(param.name).
+            description(param.description).
+            required(param.required).
+            property(registerModel(param.typ))
+      }
+
+    val bodyElements = properties.collect { case b: BodyRequestParam => b }
+
+    swaggerProps ++ List(registerDynamicBody(bodyElements, className)).flatten
+  }
+
+  /**
+   * Given the request object format its finatra parameters via reflection
+   *
+   * @tparam T
+   * @return
+   */
+  private def getFinatraProps[T: TypeTag]: List[FinatraRequestParam] = {
+    val clazz = currentMirror.runtimeClass(typeOf[T])
+
+    val fields = clazz.getDeclaredFields
+
+    val constructorArgWithField =
+      clazz.
+        getConstructors.
+        head.getParameters.
+        map(m => (clazz: Class[_ <: Annotation]) => {
+          val annotation = m.getAnnotationsByType(clazz)
+
+          if (annotation.isEmpty) {
+            None
+          } else {
+            Some(annotation)
+          }
+        }).
+        zip(fields)
+
+    val ast: List[Option[FinatraRequestParam]] =
+      constructorArgWithField.map { case (annotationExtractor, field) =>
+        val routeParam = annotationExtractor(classOf[RouteParam])
+        val queryParam = annotationExtractor(classOf[QueryParam])
+        val injectJavax = annotationExtractor(classOf[JInject])
+        val injectGuice = annotationExtractor(classOf[GInject])
+        val header = annotationExtractor(classOf[HeaderParam])
+        val form = annotationExtractor(classOf[FormParam])
+
+        val (isRequired, innerOptionType) = field.getGenericType match {
+          case parameterizedType: ParameterizedType =>
+
+            val required = parameterizedType.getRawType.asInstanceOf[Class[_]] == classOf[Option[_]]
+
+            (required, Some(parameterizedType.getActualTypeArguments.apply(0)))
+          case _ =>
+            (true, None)
+        }
+
+        if (routeParam.isDefined) {
+          Some(RouteRequestParam(field.getName, typ = field.getType))
+        }
+        else if (queryParam.isDefined) {
+          Some(QueryRequestParam(field.getName, typ = field.getType, required = isRequired))
+        }
+        else if ((injectJavax.isDefined || injectGuice.isDefined) && field.getType.isAssignableFrom(classOf[Request])) {
+          Some(RequestInjectRequestParam(field.getName))
+        }
+        else if (header.isDefined) {
+          Some(HeaderRequestParam(field.getName, typ = field.getType, required = isRequired))
+        }
+        else if (form.isDefined) {
+          Some(FormRequestParam(field.getName, typ = field.getType, required = isRequired))
+        }
+        else {
+          Some(BodyRequestParam(name = field.getName, typ = field.getType, innerOptionType = innerOptionType))
+        }
+      }.toList
+
+    ast.flatten
+  }
+
+  /**
+   * Creates a fake object for swagger to reflect upon
+   *
+   * @param bodyElements
+   * @param name
+   * @return
+   */
+  private def registerDynamicBody(bodyElements: List[BodyRequestParam], name: String): Option[Parameter] = {
+    if (bodyElements.isEmpty) {
+      return None
+    }
+
+    val bodyClass =
+    // if we have more than one body element create a new runtime class
+    // to fake out swagger
+      if (bodyElements.size > 1) {
+        val byteBuddy = new ByteBuddy()
+
+        // add "Body" to avoid name collisions
+        val bodyEmittedClass = byteBuddy.subclass(classOf[Object]).name(name + "Body")
+
+        val bodyFields = bodyElements.foldLeft(bodyEmittedClass) { (asm, body) =>
+          // if we have an inner option type, unwrap the option
+          // and pass it to the class builder so we can get proper
+          // definitions of the inner type in the swagger model
+          val bodyType = body.innerOptionType.getOrElse(body.typ).asInstanceOf[Class[_]]
+
+          asm.defineField(body.name, new TypeDescription.Generic.OfNonGenericType.ForLoadedType(bodyType), Visibility.PUBLIC)
+        }
+
+        bodyFields.make().load(getClass.getClassLoader).getLoaded
+      } else {
+        bodyElements.head.typ
+      }
+
+    val schema = registerModel(bodyClass, Some(name))
+
+    val model = schema match {
+      case null => null
+      case p: RefProperty => new RefModel(p.getSimpleRef)
+      case _ => null  //todo map ArrayProperty to ArrayModel?
+    }
+
+    Some(
+      new BodyParameter().name("body").schema(model)
+    )
+  }
 
   def registerModel[T: TypeTag]: Property = {
     val paramType: Type = typeOf[T]
-    if(paramType =:= TypeTag.Nothing.tpe) {
+    if (paramType =:= TypeTag.Nothing.tpe) {
       null
     } else {
       val typeClass = currentMirror.runtimeClass(paramType)
 
-      val modelConverters = ModelConverters.getInstance()
-      val models = modelConverters.readAll(typeClass)
-      for(entry <- models.entrySet().asScala) {
-        swagger.addDefinition(entry.getKey, entry.getValue)
-      }
-      val schema = modelConverters.readAsProperty(typeClass)
-
-      schema
+      registerModel(typeClass)
     }
+  }
+
+  private def registerModel(typeClass: Class[_], name: Option[String] = None) = {
+    val modelConverters = ModelConverters.getInstance()
+    val models = modelConverters.readAll(typeClass)
+    for (entry <- models.entrySet().asScala) {
+      swagger.addDefinition(entry.getKey, entry.getValue)
+    }
+    val schema = modelConverters.readAsProperty(typeClass)
+
+    schema
   }
 
   def convertPath(path: String): String = {
@@ -42,7 +259,7 @@ class FinatraSwagger(swagger: Swagger) {
     val swaggerPath = convertPath(path)
 
     var spath = swagger.getPath(swaggerPath)
-    if(spath == null) {
+    if (spath == null) {
       spath = new Path()
       swagger.path(swaggerPath, spath)
     }

--- a/src/test/scala/com/github/xiaodongw/swagger/finatra/Models.scala
+++ b/src/test/scala/com/github/xiaodongw/swagger/finatra/Models.scala
@@ -1,12 +1,26 @@
 package com.github.xiaodongw.swagger.finatra
 
-import io.swagger.annotations.{ApiModelProperty, ApiModel}
-import org.joda.time.{LocalDate, DateTime}
+import com.twitter.finagle.http.Request
+import com.twitter.finatra.request.RouteParam
+import io.swagger.annotations.{ApiModel, ApiModelProperty}
+import javax.inject.Inject
+import org.joda.time.{DateTime, LocalDate}
 
 @ApiModel(value="AddressModel", description="Sample address model for documentation")
 case class Address(street: String, zip: String)
 
 case class Student(firstName: String, lastName: String, gender: Gender, birthday: LocalDate, grade: Int, address: Option[Address])
+
+case class StudentWithRoute(
+  @RouteParam id: String,
+  @Inject request: Request,
+  firstName: String,
+  lastName: String,
+  gender: Gender,
+  birthday: LocalDate,
+  grade: Int,
+  address: Option[Address]
+)
 
 object CourseType extends Enumeration {
   val LEC, LAB = Value

--- a/src/test/scala/com/github/xiaodongw/swagger/finatra/SampleApp.scala
+++ b/src/test/scala/com/github/xiaodongw/swagger/finatra/SampleApp.scala
@@ -10,6 +10,8 @@ import io.swagger.util.Json
 
 object SampleSwagger extends Swagger {
   Json.mapper().setPropertyNamingStrategy(new PropertyNamingStrategy.LowerCaseWithUnderscoresStrategy)
+
+  Resolvers.register()
 }
 
 object SampleApp extends HttpServer {

--- a/src/test/scala/com/github/xiaodongw/swagger/finatra/SampleController.scala
+++ b/src/test/scala/com/github/xiaodongw/swagger/finatra/SampleController.scala
@@ -45,6 +45,17 @@ class SampleController extends Controller with SwaggerSupport {
     response.ok.json(Student("Alice", "Wang", Gender.Female, new LocalDate(), 4, Some(Address("California Street", "94111")))).toFuture
   }
 
+  postWithDoc("/students/test/:id") { o =>
+    o.summary("Sample request with route2")
+      .description("Read the detail information about the student.")
+      .tag("Student")
+      .request[StudentWithRoute]
+  } { request: StudentWithRoute =>
+    val id = request.id
+
+    response.ok.json(Student("Alice", "Wang", Gender.Female, new LocalDate(), 4, Some(Address("California Street", "94111")))).toFuture
+  }
+
   postWithDoc("/students") { o =>
     o.summary("Create a new student")
       .tag("Student")

--- a/src/test/scala/com/github/xiaodongw/swagger/finatra/SampleController.scala
+++ b/src/test/scala/com/github/xiaodongw/swagger/finatra/SampleController.scala
@@ -34,6 +34,17 @@ class SampleController extends Controller with SwaggerSupport {
     response.ok.json(Student("Alice", "Wang", Gender.Female, new LocalDate(), 4, Some(Address("California Street", "94111")))).toFuture
   }
 
+  postWithDoc("/students/:id") { o =>
+    o.summary("Sample request with route")
+      .description("Read the detail information about the student.")
+      .tag("Student")
+      .request[StudentWithRoute]
+  } { request: StudentWithRoute =>
+    val id = request.id
+
+    response.ok.json(Student("Alice", "Wang", Gender.Female, new LocalDate(), 4, Some(Address("California Street", "94111")))).toFuture
+  }
+
   postWithDoc("/students") { o =>
     o.summary("Create a new student")
       .tag("Student")
@@ -60,7 +71,7 @@ class SampleController extends Controller with SwaggerSupport {
     val name = request.getParam("name")
     val grade = request.getIntParam("grade")
     val who = request.cookies.getOrElse("who", "Sam") //todo swagger-ui not set the cookie?
-  val token = request.headerMap("token")
+    val token = request.headerMap("token")
 
     response.ok.toFuture
   }
@@ -105,4 +116,6 @@ class SampleController extends Controller with SwaggerSupport {
   } { request: Request =>
     response.ok.json(true).toFuture
   }
+
+
 }


### PR DESCRIPTION
in relation to #25 

@xiaodongw here is an initial draft of my proposal.  I've done a few things here, and there is one nagging issue that I could use some help with:

1. I added an Option[T] model resolver to properly resolve options in body params:

![image](https://cloud.githubusercontent.com/assets/1799346/21278284/2cebf516-c38f-11e6-8338-3d0bd58e889d.png)

2. I added a new `request[T]` operation that does full auto registration. It scans the fields of the case class and relies on the fact that case class constructor field order and reflective declared field order _are the same_ (i really wanted to use scala reflection but I can't figure out how to get the annotations on a constructor element... :( ).  Then we can get the field information and annotation information. We can add to this with our own annotations or even support the swagger annotations in full on them! However, there is an issue where if you have a body parameter that has multiple parameters they need to be registered as a _single_ class to swagger. To do this I used bytebuddy to emit a runtime assembly class to fake out swagger. 

here is a screenshot if it in action:

![image](https://cloud.githubusercontent.com/assets/1799346/21278381/b2e0df74-c38f-11e6-8d42-af684e619344.png)

![image](https://cloud.githubusercontent.com/assets/1799346/21278385/b7c1ebdc-c38f-11e6-93cd-4ae04946912d.png)

However, the crappy part is due to the way the asm was done the model name is mangled:

![image](https://cloud.githubusercontent.com/assets/1799346/21278399/c226a66c-c38f-11e6-8987-dcd481bb6e23.png)

If you have any suggestions on how to tweak that I would gladly do it.

Let me know what you think