### PR TITLE
Fixing when a single element is in the request body

### DIFF
--- a/src/test/scala/com/github/xiaodongw/swagger/finatra/Models.scala
+++ b/src/test/scala/com/github/xiaodongw/swagger/finatra/Models.scala
@@ -22,6 +22,11 @@ case class StudentWithRoute(
   address: Option[Address]
 )
 
+case class StringWithRequest(
+  @Inject request: Request,
+  firstName: String
+)
+
 object CourseType extends Enumeration {
   val LEC, LAB = Value
 }

--- a/src/test/scala/com/github/xiaodongw/swagger/finatra/SampleController.scala
+++ b/src/test/scala/com/github/xiaodongw/swagger/finatra/SampleController.scala
@@ -56,6 +56,13 @@ class SampleController extends Controller with SwaggerSupport {
     response.ok.json(Student("Alice", "Wang", Gender.Female, new LocalDate(), 4, Some(Address("California Street", "94111")))).toFuture
   }
 
+  postWithDoc("/students/firstName") {
+    _.request[StringWithRequest]
+      .tag("Student")
+  } { request: StringWithRequest =>
+    request.firstName
+  }
+
   postWithDoc("/students") { o =>
     o.summary("Create a new student")
       .tag("Student")


### PR DESCRIPTION
I noticed a bug in my last PR that when there is only 1 element in the request body that the request fails to serialize since it tries to send a primitive into a class body.

This fixes that issue.

![image](https://cloud.githubusercontent.com/assets/1799346/22231786/5bc9611a-e19a-11e6-8573-ac719c12805f.png)
