### PR TITLE
Fix bodyParams provided with Arrays

### DIFF
--- a/src/main/scala/com/github/xiaodongw/swagger/finatra/FinatraOperation.scala
+++ b/src/main/scala/com/github/xiaodongw/swagger/finatra/FinatraOperation.scala
@@ -89,16 +89,7 @@ class FinatraOperation(operation: Operation) {
                            (implicit swagger: Swagger): Operation = {
     val schema = swagger.registerModel[T]
 
-    val model = schema match {
-      case null => null
-      case p: RefProperty => new RefModel(p.getSimpleRef)
-      case p: ArrayProperty => {
-        val arrayModel = new ArrayModel()
-        arrayModel.setItems(p.getItems)
-        arrayModel
-      }
-      case _ => null
-    }
+    val model = SchemaUtil.toModel(schema)
 
     //todo not working
     example.foreach { e =>

--- a/src/main/scala/com/github/xiaodongw/swagger/finatra/FinatraOperation.scala
+++ b/src/main/scala/com/github/xiaodongw/swagger/finatra/FinatraOperation.scala
@@ -1,7 +1,7 @@
 package com.github.xiaodongw.swagger.finatra
 
 import io.swagger.models.parameters._
-import io.swagger.models.properties.RefProperty
+import io.swagger.models.properties.{ArrayProperty, RefProperty}
 import io.swagger.models._
 import io.swagger.util.Json
 import scala.collection.JavaConverters._
@@ -92,7 +92,12 @@ class FinatraOperation(operation: Operation) {
     val model = schema match {
       case null => null
       case p: RefProperty => new RefModel(p.getSimpleRef)
-      case _ => null  //todo map ArrayProperty to ArrayModel?
+      case p: ArrayProperty => {
+        val arrayModel = new ArrayModel()
+        arrayModel.setItems(p.getItems)
+        arrayModel
+      }
+      case _ => null
     }
 
     //todo not working

--- a/src/main/scala/com/github/xiaodongw/swagger/finatra/FinatraSwagger.scala
+++ b/src/main/scala/com/github/xiaodongw/swagger/finatra/FinatraSwagger.scala
@@ -231,7 +231,7 @@ class FinatraSwagger(swagger: Swagger) {
     val model = schema match {
       case null => null
       case p: RefProperty => new RefModel(p.getSimpleRef)
-      case _ => null  //todo map ArrayProperty to ArrayModel?
+      case _ => null
     }
 
     Some(

--- a/src/main/scala/com/github/xiaodongw/swagger/finatra/FinatraSwagger.scala
+++ b/src/main/scala/com/github/xiaodongw/swagger/finatra/FinatraSwagger.scala
@@ -228,11 +228,7 @@ class FinatraSwagger(swagger: Swagger) {
 
     val schema = registerModel(bodyClass, Some(name))
 
-    val model = schema match {
-      case null => null
-      case p: RefProperty => new RefModel(p.getSimpleRef)
-      case _ => null
-    }
+    val model = SchemaUtil.toModel(schema)
 
     Some(
       new BodyParameter().name("body").schema(model)

--- a/src/main/scala/com/github/xiaodongw/swagger/finatra/SchemaUtil.scala
+++ b/src/main/scala/com/github/xiaodongw/swagger/finatra/SchemaUtil.scala
@@ -1,0 +1,20 @@
+package com.github.xiaodongw.swagger.finatra
+
+import io.swagger.models.{ArrayModel, Model, RefModel}
+import io.swagger.models.properties.{ArrayProperty, Property, RefProperty}
+
+object SchemaUtil {
+  def toModel(schema: Property): Model = {
+    val model = schema match {
+      case null => null
+      case p: RefProperty => new RefModel(p.getSimpleRef)
+      case p: ArrayProperty => {
+        val arrayModel = new ArrayModel()
+        arrayModel.setItems(p.getItems)
+        arrayModel
+      }
+      case _ => null
+    }
+    model
+  }
+}

--- a/src/test/scala/com/github/xiaodongw/swagger/finatra/Models.scala
+++ b/src/test/scala/com/github/xiaodongw/swagger/finatra/Models.scala
@@ -19,6 +19,7 @@ case class StudentWithRoute(
   gender: Gender,
   birthday: LocalDate,
   grade: Int,
+  emails: Array[String],
   address: Option[Address]
 )
 

--- a/src/test/scala/com/github/xiaodongw/swagger/finatra/SampleController.scala
+++ b/src/test/scala/com/github/xiaodongw/swagger/finatra/SampleController.scala
@@ -74,6 +74,16 @@ class SampleController extends Controller with SwaggerSupport {
     response.ok.json(student).toFuture
   }
 
+  postWithDoc("/students/bulk") { o =>
+    o.summary("Create a list of students")
+      .tag("Student")
+      .bodyParam[Array[Student]]("students", "the list of students")
+      .responseWith[Unit](200, "the students are created")
+      .responseWith[Unit](500, "internal error")
+  } { students: List[Student] =>
+    response.ok.json(students).toFuture
+  }
+
   putWithDoc("/students/:id") { o =>
     o.summary("Update the student")
       .tag("Student")


### PR DESCRIPTION
- Handled ArrayProperty in FintratraOperation.bodyParam
- Move common code to SchemaUtil
- Created test case with posting a list of students
- Added list of emails StudentWithRoute object to check that is is properly handled inside an object

Before schema is empty for array bodyParams:
 ```
 "/students/bulk": {
      "post": {
        "parameters": [
          {
            "description": "the list of students",
            "in": "body",
            "name": "students",
            "required": false
          }
        ],
        "responses": {
           ..
          }
        },
        "summary": "Create a list of students",
        "tags": [
          "Student"
        ]
      }
    },
```
Now: 

```
 "/students/bulk": {
      "post": {
        "parameters": [
          {
            "description": "the list of students",
            "in": "body",
            "name": "students",
            "required": false,
            "schema": {
              "items": {
                "$ref": "#/definitions/Student"
              },
              "type": "array"
            }
          }
        ],
        "responses": {
           ..
          }
        },
        "summary": "Create a list of students",
        "tags": [
          "Student"
        ]
      }
    },
```