### PR TITLE
Check for ApiModelProperty annotation for request params

### DIFF
--- a/src/test/scala/com/github/xiaodongw/swagger/finatra/Models.scala
+++ b/src/test/scala/com/github/xiaodongw/swagger/finatra/Models.scala
@@ -12,9 +12,10 @@ case class Address(street: String, zip: String)
 case class Student(firstName: String, lastName: String, gender: Gender, birthday: LocalDate, grade: Int, address: Option[Address])
 
 case class StudentWithRoute(
-  @RouteParam id: String,
+  @RouteParam
+  @ApiModelProperty(name = "student_id", value = "Id of the student")
+  id: String,
   @Inject request: Request,
-  @QueryParam
   firstName: String,
   lastName: String,
   gender: Gender,
@@ -32,15 +33,6 @@ case class StringWithRequest(
 object CourseType extends Enumeration {
   val LEC, LAB = Value
 }
-
-case class CourseRequest(
-  @QueryParam
-  @ApiModelProperty(
-    name = "max_capacity",
-    value = "Max capacity description"
-  )
-  maxCapacity: Int
-)
 
 case class Course(time: DateTime,
                   name: String,

--- a/src/test/scala/com/github/xiaodongw/swagger/finatra/Models.scala
+++ b/src/test/scala/com/github/xiaodongw/swagger/finatra/Models.scala
@@ -1,7 +1,7 @@
 package com.github.xiaodongw.swagger.finatra
 
 import com.twitter.finagle.http.Request
-import com.twitter.finatra.request.RouteParam
+import com.twitter.finatra.request.{QueryParam, RouteParam}
 import io.swagger.annotations.{ApiModel, ApiModelProperty}
 import javax.inject.Inject
 import org.joda.time.{DateTime, LocalDate}
@@ -14,6 +14,7 @@ case class Student(firstName: String, lastName: String, gender: Gender, birthday
 case class StudentWithRoute(
   @RouteParam id: String,
   @Inject request: Request,
+  @QueryParam
   firstName: String,
   lastName: String,
   gender: Gender,
@@ -31,6 +32,15 @@ case class StringWithRequest(
 object CourseType extends Enumeration {
   val LEC, LAB = Value
 }
+
+case class CourseRequest(
+  @QueryParam
+  @ApiModelProperty(
+    name = "max_capacity",
+    value = "Max capacity description"
+  )
+  maxCapacity: Int
+)
 
 case class Course(time: DateTime,
                   name: String,

--- a/src/test/scala/com/github/xiaodongw/swagger/finatra/SampleController.scala
+++ b/src/test/scala/com/github/xiaodongw/swagger/finatra/SampleController.scala
@@ -133,15 +133,6 @@ class SampleController extends Controller with SwaggerSupport {
     response.ok.json(Course(new DateTime(), "calculation", Seq("math"), CourseType.LAB, 20, BigDecimal(300.54))).toFuture
   }
 
-  getWithDoc("/courses/query") { o =>
-    o.summary("Query courses")
-      .tag("Course")
-      .request[CourseRequest]
-      .responseWith[Array[String]](200, "the courses ids")
-  } { request: CourseRequest =>
-    response.ok.json(Array("course1", "course2")).toFuture
-  }
-
   filter[SampleFilter].getWithDoc("/courses/:courseId/student/:studentId") { o =>
     o.summary("Is the student in this course")
       .tags(List("Course", "Student"))

--- a/src/test/scala/com/github/xiaodongw/swagger/finatra/SampleController.scala
+++ b/src/test/scala/com/github/xiaodongw/swagger/finatra/SampleController.scala
@@ -133,6 +133,15 @@ class SampleController extends Controller with SwaggerSupport {
     response.ok.json(Course(new DateTime(), "calculation", Seq("math"), CourseType.LAB, 20, BigDecimal(300.54))).toFuture
   }
 
+  getWithDoc("/courses/query") { o =>
+    o.summary("Query courses")
+      .tag("Course")
+      .request[CourseRequest]
+      .responseWith[Array[String]](200, "the courses ids")
+  } { request: CourseRequest =>
+    response.ok.json(Array("course1", "course2")).toFuture
+  }
+
   filter[SampleFilter].getWithDoc("/courses/:courseId/student/:studentId") { o =>
     o.summary("Is the student in this course")
       .tags(List("Course", "Student"))


### PR DESCRIPTION
Currently, there is no way to give custom names or descriptions to properties of a custom request when using the `request[T]` function on the operation. It will just take the actual name of the property and leave the description blank.

This pr adds functionality so that you can use add the `@ApiModelProperty` annotation to decorate the custom request case class properties so that the resulting swagger docs will have the custom names and descriptions.

```
case class CourseRequest {
  @QueryParam
  @ApiModelProperty(name = "max_capacity", description = "blah description")
  maxCapacity: Int
}
```